### PR TITLE
Add attribution to AISLER

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 PCBWay and contributors
+Copyright (c) 2022 AISLER B.V., https://aisler.net
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ As a sponsor of KiCad, we will always support its development.
 ![pcbway and kicad](https://user-images.githubusercontent.com/20063837/161211870-b4a46c17-2e1c-45b4-bfe7-2ab97ade157d.png)
 
 
+This Plug-In is provided by [AISLER](https://aisler.net) (https://aisler.net)
+
+![aisler](https://aisler.net/logos/logo_medium.png)
+
 
 
 

--- a/plugins/thread.py
+++ b/plugins/thread.py
@@ -1,5 +1,6 @@
-#copyright  Aisler and licensed under the MIT license.
-#https://opensource.org/licenses/MIT 
+# Copyright AISLER B.V., https://aisler.net
+# Licensed under the MIT license.
+# https://opensource.org/licenses/MIT 
 
 import os
 import webbrowser


### PR DESCRIPTION
This is required by the MIT license. We are happy to support the development of this plugin, just get into contact with us. I'd suggest to also merge a few improvements we made to the plugin.