### PR TITLE
Fix KiCad 10 compatibility: use HasField/GetField API

### DIFF
--- a/plugins/utils.py
+++ b/plugins/utils.py
@@ -31,14 +31,21 @@ def is_v9():
 def is_greater_v8():
     return get_version() >= 7.99
 
+def is_greater_v10():
+    return get_version() >= 9.99
+
 def footprint_has_field(footprint, field_name):
-    if is_greater_v8():
+    if is_greater_v10():
+        return footprint.HasField(field_name)
+    elif is_greater_v8():
         return footprint.HasFieldByName(field_name)
     else:
         return footprint.HasProperty(field_name)
 
 def footprint_get_field(footprint, field_name):
-    if is_greater_v8():
+    if is_greater_v10():
+        return footprint.GetField(field_name).GetText()
+    elif is_greater_v8():
         return footprint.GetFieldByName(field_name).GetText()
     else:
         return footprint.GetProperty(field_name)


### PR DESCRIPTION
KiCad 10 renamed HasFieldByName and GetFieldByName on FOOTPRINT objects to HasField and GetField, causing the plugin to crash with:

'FOOTPRINT' object has no attribute 'HasFieldByName'

  - Add is_greater_v9() version helper
  - Update footprint_has_field and footprint_get_field in utils.py to dispatch to HasField/GetField for KiCad 10+, HasFieldByName/GetFieldByName for KiCad 8–9, and HasProperty/GetProperty for older versions

Backward compatible — no behavior change for KiCad 8/9 users.

Fixes #28